### PR TITLE
Remote DB Tests

### DIFF
--- a/tests/testthat/test-execute.R
+++ b/tests/testthat/test-execute.R
@@ -14,7 +14,7 @@ test_that("Execute a single DQ check on Synthea/Eunomia", {
                              checkNames = "measurePersonCompleteness",
                              outputFolder = tempdir(),
                              writeToTable = F)
-  
+
   expect_true(nrow(results$CheckResults) > 1)
 })
 
@@ -39,7 +39,7 @@ test_that("Execute FIELD checks on Synthea/Eunomia", {
                              checkLevels = "FIELD",
                              outputFolder = tempdir(),
                              writeToTable = F)
-  
+
   expect_true(nrow(results$CheckResults) > 0)
 })
 
@@ -52,48 +52,46 @@ test_that("Execute FIELD checks on Synthea/Eunomia", {
 #                              checkLevels = "CONCEPT",
 #                              outputFolder = tempdir(),
 #                              writeToTable = F)
-#   
+# 
 #   expect_true(nrow(results$CheckResults) > 0)
 # })
 
-# test_that("Execute DQ checks on remote databases", {
-#   
-#   dbTypes = c("oracle",
-#               "postgresql",
-#               "sql server")
-#               
-#   for (dbType in dbTypes) {
-#     sysUser <- Sys.getenv(sprintf("CDM5_%s_USER", toupper(dbType)))
-#     sysPassword <- URLdecode(Sys.getenv(sprintf("CDM5_%s_PASSWORD", toupper(dbType))))
-#     sysServer <- Sys.getenv(sprintf("CDM5_%s_SERVER", toupper(dbType)))
-#     sysExtraSettings <- Sys.getenv(sprintf("CDM5_%s_EXTRA_SETTINGS", toupper(dbType)))
-#     if (sysUser != "" &
-#         sysPassword != "" &
-#         sysServer != "") {
-#       cdmDatabaseSchema <- Sys.getenv(sprintf("CDM5_%s_CDM_SCHEMA", toupper(dbType)))
-#       resultsDatabaseSchema <- Sys.getenv("CDM5_%s_OHDSI_SCHEMA", toupper(dbType))
-#       
-#       connectionDetails <- createConnectionDetails(dbms = dbType,
-#                                          user = sysUser,
-#                                          password = sysPassword,
-#                                          server = sysServer,
-#                                          extraSettings = sysExtraSettings)
-#     
-#       results <- executeDqChecks(connectionDetails = connectionDetails, 
-#                                  cdmDatabaseSchema = cdmDatabaseSchema, 
-#                                  resultsDatabaseSchema = resultsDatabaseSchema, 
-#                                  cdmSourceName = "test", 
-#                                  numThreads = 1, 
-#                                  sqlOnly = FALSE, 
-#                                  outputFolder = "output", 
-#                                  verboseMode = FALSE, 
-#                                  writeToTable = FALSE, 
-#                                  checkLevels = c(), 
-#                                  checkNames = c())
-#       
-#       expect_true(nrow(results$CheckResults) > 0)
-#     }
-#   }
-# })
-# 
+test_that("Execute a single DQ check on remote databases", {
 
+  dbTypes = c("oracle",
+              "postgresql",
+              "sql server")
+
+  for (dbType in dbTypes) {
+    sysUser <- Sys.getenv(sprintf("CDM5_%s_USER", toupper(dbType)))
+    sysPassword <- URLdecode(Sys.getenv(sprintf("CDM5_%s_PASSWORD", toupper(dbType))))
+    sysServer <- Sys.getenv(sprintf("CDM5_%s_SERVER", toupper(dbType)))
+    sysExtraSettings <- Sys.getenv(sprintf("CDM5_%s_EXTRA_SETTINGS", toupper(dbType)))
+    if (sysUser != "" &
+        sysPassword != "" &
+        sysServer != "") {
+      cdmDatabaseSchema <- Sys.getenv(sprintf("CDM5_%s_CDM_SCHEMA", toupper(dbType)))
+      resultsDatabaseSchema <- Sys.getenv("CDM5_%s_OHDSI_SCHEMA", toupper(dbType))
+
+      connectionDetails <- createConnectionDetails(dbms = dbType,
+                                         user = sysUser,
+                                         password = sysPassword,
+                                         server = sysServer,
+                                         extraSettings = sysExtraSettings)
+
+      results <- executeDqChecks(connectionDetails = connectionDetails,
+                                 cdmDatabaseSchema = cdmDatabaseSchema,
+                                 resultsDatabaseSchema = resultsDatabaseSchema,
+                                 cdmSourceName = "test",
+                                 numThreads = 1,
+                                 sqlOnly = FALSE,
+                                 outputFolder = "output",
+                                 verboseMode = FALSE,
+                                 writeToTable = FALSE,
+                                 checkNames = "measurePersonCompleteness"
+                                 )
+
+      expect_true(nrow(results$CheckResults) > 0)
+    }
+  }
+})


### PR DESCRIPTION
Reduce tests against the remote OHDSI databases to run only 1 DQD check.  Running all checks took too long; this way we have some basic functionality in place to test that DQD can run against these databases.  In the longer term we'll develop a testing strategy that lets us test more aspects of the DQD package in a lightweight manner.  